### PR TITLE
Update Gemfile.lock after bumping nxt_support version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.1.11)
+    nxt_support (0.1.12)
       nxt_init
       nxt_registry
       rails


### PR DESCRIPTION
Forgot to run `bundle` in the [previous PR](https://github.com/nxt-insurance/nxt_support/pull/40). This bumps the version of `nxt_support` in Gemfile.lock