### PR TITLE
Do not allow consecutive dots

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.1.15)
+    nxt_support (0.1.16)
       activerecord
       activesupport
       nxt_init
@@ -10,27 +10,27 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3)
-      activesupport (= 6.1.3)
-    activerecord (6.1.3)
-      activemodel (= 6.1.3)
-      activesupport (= 6.1.3)
-    activesupport (6.1.3)
+    activemodel (6.1.3.2)
+      activesupport (= 6.1.3.2)
+    activerecord (6.1.3.2)
+      activemodel (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+    activesupport (6.1.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.14.4)
     nxt_init (0.1.5)
       activesupport
-    nxt_registry (0.3.9)
+    nxt_registry (0.3.10)
       activesupport
     pry (0.14.0)
       coderay (~> 1.1)

--- a/lib/nxt_support/models/email.rb
+++ b/lib/nxt_support/models/email.rb
@@ -7,6 +7,6 @@ module NxtSupport
     #  (4) No dot ('.') character directly after the '@' character
     #  (5) A hostname after the '@' character of at least one non-whitespace characters length
     #  (6) At least one top level domain ending (e.g. '.com') after the hostname, separated from the hostname by a dot ('.')
-    REGEXP = /\A[^@\s]+@([^\.@\s]+\.)+[^@\s]+\z/.freeze
+    REGEXP = /\A[^@\s]+@([^.@\s]+\.)+[^.^@\s]+\z/.freeze
   end
 end

--- a/lib/nxt_support/version.rb
+++ b/lib/nxt_support/version.rb
@@ -1,3 +1,3 @@
 module NxtSupport
-  VERSION = "0.1.15".freeze
+  VERSION = "0.1.16".freeze
 end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NxtSupport::Email do
     end
 
     let(:invalid_emails) do
-      ['john doe@example.org', 'john@.example.org', 'john@example']
+      ['john doe@example.org', 'john@.example.org', 'john@example', 'john@example..org', 'john@example.org.', 'john@.example.org']
     end
 
     it 'matches valid emails' do


### PR DESCRIPTION
There have been a case where user signed up with email containing two consecutive dots in the domain, and failed to purchase dental insurance later on.

(The issue with that particular customer has been resolved by redoing the signup)