### PR TITLE
Methods to access all values of Enum

### DIFF
--- a/lib/nxt_support/util/enum.rb
+++ b/lib/nxt_support/util/enum.rb
@@ -24,6 +24,14 @@ module NxtSupport
       store
     end
 
+    def strings
+      values
+    end
+
+    def symbols
+      values.map(&:to_sym)
+    end
+
     delegate_missing_to :to_h
 
     private

--- a/spec/util/enum_spec.rb
+++ b/spec/util/enum_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe NxtSupport::Enum do
       expect(subject.lütfi).to eq('Lütfi')
     end
   end
+
+  describe '#strings' do
+    it 'returns all values' do
+      expect(subject.strings).to eq(['Nils Sommer', 'Rapha BIG Dog', 'Lütfi'])
+    end
+  end
+
+  describe '#symbols' do
+    it 'returns all values as symbols' do
+      expect(subject.symbols).to eq([:'Nils Sommer', :'Rapha BIG Dog', :'Lütfi'])
+    end
+  end
 end


### PR DESCRIPTION
Methods to easily provide all values as strings or symbols
`Enum['yesid'].symbols => [:yesid]`
`Enum['shalvah'].strings => ['shalvah']`
