### PR TITLE
Add Sentry error ID middleware

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby-version: ["2.6.8", "2.7.4", "3.0.2"]
+              ruby-version: ["3.0.2", "3.1.2"]
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby-version: ["3.0.2", "3.1.2"]
+              ruby-version: ["3.0.2", "3.1.0"]
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ workflows:
           matrix:
             parameters:
               ruby-version: ["3.0.2", "3.1.2"]
+orbs:
+  ruby: circleci/ruby@2.0.0
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby-version: ["3.0.2", "3.1.0"]
+              ruby-version: ["3.0.2", "3.1.2"]
 
 jobs:
   build:
@@ -20,39 +20,13 @@ jobs:
 
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:<< parameters.ruby-version >>-node
+      - image: cimg/ruby:<< parameters.ruby-version >>
 
     working_directory: ~/repo
 
     steps:
-      - checkout
+      - checkout- ruby/install-deps:
 
-      - run:
-          name: Install apt dependencies
-          command: |
-            sudo apt update -q \
-            && sudo apt upgrade -q \
-            && sudo apt install -qy --no-install-recommends \
-              sqlite3 libsqlite3-dev
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      - run: gem install bundler
-
-      - run:
-          name: install dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
-
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      # run tests!
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - checkout- ruby/install-deps:
-
+      - checkout
+      - ruby/install-deps
       - run:
           name: run tests
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.4.0 2022-11-14
+- Add `SentryErrorID` middleware
+
 # v0.3.0 2022-05-30
 - Support passing `with` to refinement
 - Call ambiguity handler with resolved collection rather than original collection, to avoid logging huge values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.4.0 2022-11-14
 - Add `SentryErrorID` middleware
+- Drop support for Ruby 2.x
 
 # v0.3.0 2022-05-30
 - Support passing `with` to refinement

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.2.1)
+    nxt_support (0.3.0)
       activerecord
       activesupport
       nxt_init

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.3.0)
+    nxt_support (0.4.0)
       activerecord
       activesupport
       nxt_init
@@ -10,24 +10,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4.1)
-      activesupport (= 6.1.4.1)
-    activerecord (6.1.4.1)
-      activemodel (= 6.1.4.1)
-      activesupport (= 6.1.4.1)
-    activesupport (6.1.4.1)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
-    i18n (1.8.10)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.14.4)
+    minitest (5.16.3)
     nxt_init (0.1.5)
       activesupport
     nxt_registry (0.3.10)
@@ -52,9 +51,8 @@ GEM
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     sqlite3 (1.4.2)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ Or install it yourself as:
 
 Here's an overview all the supporting features.
 
+### NxtSupport::Middleware::SentryErrorID
+A Rack middleware that adds a `Sentry-Error-ID` header to 5xx responses. 
+The header is only added if an error was reported during the request. 
+The error ID is gotten from [`sentry.error_event_id` in the Rack env](https://github.com/getsentry/sentry-ruby/pull/1849)).
+You can then visit `https://sentry.io/organizations/<org-slug>>?query=<error-event-id>`
+to go directly to the error (it may not show up immediately).
+
+Note that this middleware must be inserted before Sentry's own middleware. 
+You can run `rails middleware` to verify the order of your registered middleware.
+
+```rb
+config.middleware.insert_before 0, NxtSupport::Middleware::SentryErrorID
+```
+
 ### NxtSupport/Models
 
 Enjoy support for your models.

--- a/lib/nxt_support.rb
+++ b/lib/nxt_support.rb
@@ -8,6 +8,7 @@ require "nxt_support/serializers"
 require "nxt_support/util"
 require "nxt_support/services"
 require "nxt_support/refinements"
+require "nxt_support/middleware"
 
 module NxtSupport
 end

--- a/lib/nxt_support/middleware.rb
+++ b/lib/nxt_support/middleware.rb
@@ -1,0 +1,1 @@
+require_relative 'middleware/sentry_error_id'

--- a/lib/nxt_support/middleware/sentry_error_id.rb
+++ b/lib/nxt_support/middleware/sentry_error_id.rb
@@ -1,0 +1,17 @@
+module NxtSupport
+  module Middleware
+    class SentryErrorID
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        status, headers, body = @app.call(env)
+        if status >= 500
+          headers["Sentry-Error-ID"] = env['sentry.error_event_id'] if env['sentry.error_event_id']
+        end
+        [status, headers, body]
+      end
+    end
+  end
+end

--- a/lib/nxt_support/middleware/sentry_error_id.rb
+++ b/lib/nxt_support/middleware/sentry_error_id.rb
@@ -7,8 +7,8 @@ module NxtSupport
 
       def call(env)
         status, headers, body = @app.call(env)
-        if status >= 500
-          headers["Sentry-Error-ID"] = env['sentry.error_event_id'] if env['sentry.error_event_id']
+        if status >= 500 && env['sentry.error_event_id']
+          headers["Sentry-Error-ID"] = env['sentry.error_event_id']
         end
         [status, headers, body]
       end

--- a/lib/nxt_support/version.rb
+++ b/lib/nxt_support/version.rb
@@ -1,3 +1,3 @@
 module NxtSupport
-  VERSION = "0.3.0".freeze
+  VERSION = "0.4.0".freeze
 end

--- a/nxt_support.gemspec
+++ b/nxt_support.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_dependency "activerecord"
   spec.add_dependency "activesupport"

--- a/spec/refinements/crystalizer_spec.rb
+++ b/spec/refinements/crystalizer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe NxtSupport::Refinements::Crystalizer do
 
     context 'without refinement' do
       it 'raises an error' do
-        expect { OrdinaryClass.new([1, 1, 1]).crystalize }.to raise_error(NoMethodError, "undefined method `crystalize' for [1, 1, 1]:Array")
+        expect { OrdinaryClass.new([1, 1, 1]).crystalize }.to raise_error(NoMethodError, /undefined method `crystalize'/)
       end
     end
 


### PR DESCRIPTION
Part of [IPDE-813](https://hellogetsafe.atlassian.net/browse/IPDE-813)

Adds a middleware that will include the ID of any error reported to Sentry in 5xx responses.