### PR TITLE
Rename header (`Sentry-Error-ID` -> `Sentry-Error-Id`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.4.1 2022-11-18
+- Rename header to `Sentry-Error-Id` for consistency
+
 # v0.4.0 2022-11-14
 - Add `SentryErrorID` middleware
 - Drop support for Ruby 2.x

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.4.0)
+    nxt_support (0.4.1)
       activerecord
       activesupport
       nxt_init

--- a/README.md
+++ b/README.md
@@ -417,7 +417,22 @@ HomeBuilder.build(width: 20, length: 40, height: 15, roof_type: :pitched)
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. 
+
+
+First, if you don't want to always log in with your RubyGems password, you can create an API key from the web, and then:
+
+```shell
+bundle config set gem.push_key rubygems
+```
+
+Add to `~/.gem/credentials` (create if it doesn't exist):
+
+```shell
+:rubygems: <your Rubygems API key>
+```
+
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/lib/nxt_support/middleware/sentry_error_id.rb
+++ b/lib/nxt_support/middleware/sentry_error_id.rb
@@ -8,7 +8,7 @@ module NxtSupport
       def call(env)
         status, headers, body = @app.call(env)
         if status >= 500 && env['sentry.error_event_id']
-          headers["Sentry-Error-ID"] = env['sentry.error_event_id']
+          headers["Sentry-Error-Id"] = env['sentry.error_event_id']
         end
         [status, headers, body]
       end

--- a/lib/nxt_support/version.rb
+++ b/lib/nxt_support/version.rb
@@ -1,3 +1,3 @@
 module NxtSupport
-  VERSION = "0.4.0".freeze
+  VERSION = "0.4.1".freeze
 end


### PR DESCRIPTION
It seems, when parsing responses, Typhoeus converts this header to `Sentry-Error-Id` ("Id" instead of "ID"). It's probably better to go with that for consistency with things like `X-Request-Id`.