### PR TITLE
`Sentry-Error-Id`: Set `Access-Control-Expose-Headers` so frontend can access header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.4.2 2022-12-19
+- `Sentry-Error-Id`: Set `Access-Control-Expose-Headers` so frontend can access header
+
 # v0.4.1 2022-11-18
 - Rename header to `Sentry-Error-Id` for consistency
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.4.1)
+    nxt_support (0.4.2)
       activerecord
       activesupport
       nxt_init

--- a/lib/nxt_support.rb
+++ b/lib/nxt_support.rb
@@ -8,7 +8,9 @@ require "nxt_support/serializers"
 require "nxt_support/util"
 require "nxt_support/services"
 require "nxt_support/refinements"
-require "nxt_support/middleware"
+
+require 'nxt_support/middleware/sentry_error_id'
+
 
 module NxtSupport
 end

--- a/lib/nxt_support/middleware.rb
+++ b/lib/nxt_support/middleware.rb
@@ -1,1 +1,0 @@
-require_relative 'middleware/sentry_error_id'

--- a/lib/nxt_support/middleware/sentry_error_id.rb
+++ b/lib/nxt_support/middleware/sentry_error_id.rb
@@ -8,8 +8,9 @@ module NxtSupport
       def call(env)
         status, headers, body = @app.call(env)
         if status >= 500 && env['sentry.error_event_id']
-          headers["Sentry-Error-Id"] = env['sentry.error_event_id']
-          headers["Access-Control-Expose-Headers"] = "*"
+          headers['Sentry-Error-Id'] = env['sentry.error_event_id']
+          exposed_headers = headers['Access-Control-Expose-Headers'] || headers['access-control-expose-headers']
+          headers['Access-Control-Expose-Headers'] = [exposed_headers, 'Sentry-Error-Id'].compact.join(', ')
         end
         [status, headers, body]
       end

--- a/lib/nxt_support/middleware/sentry_error_id.rb
+++ b/lib/nxt_support/middleware/sentry_error_id.rb
@@ -9,6 +9,7 @@ module NxtSupport
         status, headers, body = @app.call(env)
         if status >= 500 && env['sentry.error_event_id']
           headers["Sentry-Error-Id"] = env['sentry.error_event_id']
+          headers["Access-Control-Expose-Headers"] = "*"
         end
         [status, headers, body]
       end

--- a/lib/nxt_support/version.rb
+++ b/lib/nxt_support/version.rb
@@ -1,3 +1,3 @@
 module NxtSupport
-  VERSION = "0.4.1".freeze
+  VERSION = "0.4.2".freeze
 end


### PR DESCRIPTION
Without this, JavaScript in the browser is unable to read the value of Sentry-Error-Id. Fuckin' CORS. 🙄 

[IPDE-815](https://hellogetsafe.atlassian.net/browse/IPDE-815)

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers

> Only the [CORS-safelisted response headers](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header) are exposed by default. For clients to be able to access other headers, the server must list them using the Access-Control-Expose-Headers header.