### PR TITLE
Fix .validate_duration(s) when used in combination with duration_attribute_accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.6.2 2026-04-30
+- Fix `.validate_duration` and `.validates_durations` when used in combination with `duration_attribute_accessor`
+
 # v0.6.1 2026-04-30
 - Added `.validate_duration` and `.validates_durations` to `NxtSupport::DurationAttributeAccessor`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.6.1)
+    nxt_support (0.6.2)
       activerecord
       activesupport
       nxt_init

--- a/lib/nxt_support/models/duration_attribute_accessor.rb
+++ b/lib/nxt_support/models/duration_attribute_accessor.rb
@@ -22,7 +22,9 @@ module NxtSupport
       
       def validates_durations(*attrs, **opts)
         validates_each(*attrs, **opts) do |record, attr, value|
-          record.errors.add attr, "is not a valid iso8601 duration." unless record.is_valid_iso8601_duration?(value)
+          next if value.is_a?(ActiveSupport::Duration)
+          next if record.is_valid_iso8601_duration?(value)
+          record.errors.add attr, "is not a valid iso8601 duration."
         end
       end
       

--- a/lib/nxt_support/version.rb
+++ b/lib/nxt_support/version.rb
@@ -1,3 +1,3 @@
 module NxtSupport
-  VERSION = "0.6.1".freeze
+  VERSION = "0.6.2".freeze
 end

--- a/spec/models/duration_attribute_accessor_spec.rb
+++ b/spec/models/duration_attribute_accessor_spec.rb
@@ -198,5 +198,58 @@ RSpec.describe NxtSupport::DurationAttributeAccessor do
         expect(record.errors[:topic_duration]).to be_present
       end
     end
+
+    context 'when using duration_attribute_accessor for the fields' do
+      subject(:klass) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = 'courses'
+          include NxtSupport::DurationAttributeAccessor
+
+          duration_attribute_accessor :class_duration, :topic_duration
+
+          validates_durations :class_duration, :topic_duration
+        end
+      end
+
+      context 'when the value is an ActiveSupport::Duration' do
+        it 'does not add an error' do
+          record = klass.new(class_duration: 1.hour, topic_duration: 1.month)
+          expect(record).to be_valid
+        end
+      end
+
+      context 'when the value is a valid ISO8601 duration string' do
+        it 'does not add an error' do
+          record = klass.new(class_duration: 'PT1H', topic_duration: 'P1M')
+          expect(record).to be_valid
+        end
+      end
+
+      context 'when the value is nil and allow_nil is not set' do
+        it 'adds an error' do
+          record = klass.new(class_duration: nil)
+          expect(record).not_to be_valid
+          expect(record.errors[:class_duration]).to include('is not a valid iso8601 duration.')
+        end
+      end
+
+      context 'with allow_nil: true' do
+        subject(:klass) do
+          Class.new(ActiveRecord::Base) do
+            self.table_name = 'courses'
+            include NxtSupport::DurationAttributeAccessor
+
+            duration_attribute_accessor :class_duration
+
+            validates_durations :class_duration, allow_nil: true
+          end
+        end
+
+        it 'does not add an error for nil' do
+          record = klass.new(class_duration: nil)
+          expect(record).to be_valid
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When used in combination with `duration_attribute_accessor` the reader returns an `ActiveSupport::Duration` object rather than the bare string which made the validation method fail. This obviously should work, but was missed because the specs just used ActiveModels with normal `attr_accessor`s. Both scenarios should work ultimately.