### PR TITLE
Fix crystalizer bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.6.3 2026-08-11
+- Fix `Crystalizer#call` to return the resolved value from a custom `on_ambiguity` handler instead of always returning `unique_values.first`
+
 # v0.6.2 2026-04-30
 - Fix `.validate_duration` and `.validates_durations` when used in combination with `duration_attribute_accessor`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nxt_support (0.6.2)
+    nxt_support (0.6.3)
       activerecord
       activesupport
       nxt_init

--- a/lib/nxt_support/util/crystalizer.rb
+++ b/lib/nxt_support/util/crystalizer.rb
@@ -7,8 +7,9 @@ module NxtSupport
     attr_init :collection, on_ambiguity: -> { default_ambiguity_handler }, with: :itself
 
     def call
-      ensure_unanimity
-      unique_values.first
+      return unique_values.first if unique_values.size == 1
+
+      on_ambiguity.arity == 1 ? on_ambiguity.call(resolved_collection) : on_ambiguity.call
     end
 
     private
@@ -23,12 +24,6 @@ module NxtSupport
 
     def default_ambiguity_handler
       ->(collection) { raise Error, "Values in collection are not unanimous: #{collection}" }
-    end
-
-    def ensure_unanimity
-      return if unique_values.size == 1
-
-      on_ambiguity.arity == 1 ? on_ambiguity.call(resolved_collection) : on_ambiguity.call
     end
   end
 end

--- a/lib/nxt_support/version.rb
+++ b/lib/nxt_support/version.rb
@@ -1,3 +1,3 @@
 module NxtSupport
-  VERSION = "0.6.2".freeze
+  VERSION = "0.6.3".freeze
 end

--- a/spec/nxt_support/util/crystalizer_spec.rb
+++ b/spec/nxt_support/util/crystalizer_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe NxtSupport::Crystalizer do
           described_class.new(collection: collection, on_ambiguity: custom_handler).call
         end
 
-        # Testing with different methods with different excepted outcomes just so
+        # Testing with different methods with different expected outcomes just so
         # the test isn't tautological.
 
         context 'with #max' do

--- a/spec/nxt_support/util/crystalizer_spec.rb
+++ b/spec/nxt_support/util/crystalizer_spec.rb
@@ -105,16 +105,44 @@ RSpec.describe NxtSupport::Crystalizer do
       end
     end
 
-    context 'custom on_ambiquity handler' do
+    context 'custom on_ambiguity handler' do
       let(:collection) { %w[anthony aki] }
-      let(:custom_handler) { -> { raise ZeroDivisionError, 'oh oh' } }
 
-      subject do
-        described_class.new(collection:, on_ambiguity: custom_handler).call
+      context 'when the handler raises' do
+        let(:custom_handler) { -> { raise ZeroDivisionError, 'oh oh' } }
+
+        subject do
+          described_class.new(collection: collection, on_ambiguity: custom_handler).call
+        end
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ZeroDivisionError)
+        end
       end
 
-      it 'raises an error' do
-        expect { subject }.to raise_error(ZeroDivisionError)
+      context 'when the handler resolves the ambiguity' do
+        subject do
+          described_class.new(collection: collection, on_ambiguity: custom_handler).call
+        end
+
+        # Testing with different methods with different excepted outcomes just so
+        # the test isn't tautological.
+
+        context 'with #max' do
+          let(:custom_handler) { ->(values) { values.max } }
+
+          it 'returns the resolved value' do
+            expect(subject).to eq('anthony')
+          end
+        end
+
+        context 'with #last' do
+          let(:custom_handler) { ->(values) { values.last } }
+
+          it 'returns the resolved value' do
+            expect(subject).to eq('aki')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Crystalizer currently behaves pretty much like `Array#first` (except the block could raise an error or apply some kind of destructive operation on the array), which is obviously not intended. This PR fixes the bug that existed since ever.

(I personally prefer using `Enumerable#sole` which has been natively available since some time now in combination with `#uniq` and explicit error handling)